### PR TITLE
verify array is not None in collection for array_contains condition

### DIFF
--- a/mockfirestore/query.py
+++ b/mockfirestore/query.py
@@ -145,7 +145,7 @@ class Query:
         elif op == 'in':
             return lambda x, y: x in y
         elif op == 'array_contains':
-            return lambda x, y: y in x
+            return lambda x, y: x is not None and y in x
         elif op == 'array_contains_any':
             return lambda x, y: any([val in y for val in x])
 


### PR DESCRIPTION
This PR updates the array_contains filter logic to avoid returning None when the field being queried is missing (None). Instead, it ensures that the filter behaves consistently with Firestore’s behavior—by excluding the document from results rather than erroring or returning None.

Fixes : https://github.com/mdowds/python-mock-firestore/issues/66

Saw fix in https://github.com/mdowds/python-mock-firestore/pull/67/files
Could you either merge my PR or the above to your fork?
Using your fork since it's better maintained than the original.

