### PR TITLE
Fix collection and query iterable issue

### DIFF
--- a/mockfirestore/collection.py
+++ b/mockfirestore/collection.py
@@ -26,7 +26,7 @@ class CollectionReference:
         return DocumentReference(self._data, new_path, parent=self)
 
     def get(self) -> Iterable[DocumentSnapshot]:
-        # Stream uses a generator, so we need to convert it to a list
+        # Stream uses a generator, so we need to convert it to a list for compatibility for .get() method with firestore library
         return list(self.stream())
     
     @property
@@ -126,7 +126,7 @@ class CollectionGroupReference(CollectionReference):
         return ret
     
     def get(self) -> Iterable[DocumentSnapshot]:
-        # Stream uses a generator, so we need to convert it to a list for compatibility with firestore library
+        # Stream uses a generator, so we need to convert it to a list for compatibility for .get() method with firestore library
         return list(self.stream())
 
     def stream(self, transaction=None) -> Iterable[DocumentSnapshot]:

--- a/mockfirestore/collection.py
+++ b/mockfirestore/collection.py
@@ -26,9 +26,8 @@ class CollectionReference:
         return DocumentReference(self._data, new_path, parent=self)
 
     def get(self) -> Iterable[DocumentSnapshot]:
-        warnings.warn('Collection.get is deprecated, please use Collection.stream',
-                      category=DeprecationWarning)
-        return self.stream()
+        # Stream uses a generator, so we need to convert it to a list
+        return list(self.stream())
     
     @property
     def path(self):
@@ -127,9 +126,8 @@ class CollectionGroupReference(CollectionReference):
         return ret
     
     def get(self) -> Iterable[DocumentSnapshot]:
-        warnings.warn('Collection.get is deprecated, please use Collection.stream',
-                      category=DeprecationWarning)
-        return self.stream()
+        # Stream uses a generator, so we need to convert it to a list for compatibility with firestore library
+        return list(self.stream())
 
     def stream(self, transaction=None) -> Iterable[DocumentSnapshot]:
         for path in self._path:

--- a/mockfirestore/query.py
+++ b/mockfirestore/query.py
@@ -60,8 +60,7 @@ class Query:
         return iter(list(doc_snapshots))
 
     def get(self) -> Iterator[DocumentSnapshot]:
-        warnings.warn('Query.get is deprecated, please use Query.stream',
-                      category=DeprecationWarning)
+        # Stream uses a generator, so we need to convert it to a list for compatibility for .get() method with firestore library
         return list(self.stream())
 
     def _add_field_filter(self, field: str, op: str, value: Any):

--- a/mockfirestore/query.py
+++ b/mockfirestore/query.py
@@ -57,12 +57,12 @@ class Query:
         if self._limit:
             doc_snapshots = islice(doc_snapshots, self._limit)
 
-        return iter(doc_snapshots)
+        return iter(list(doc_snapshots))
 
     def get(self) -> Iterator[DocumentSnapshot]:
         warnings.warn('Query.get is deprecated, please use Query.stream',
                       category=DeprecationWarning)
-        return self.stream()
+        return list(self.stream())
 
     def _add_field_filter(self, field: str, op: str, value: Any):
         compare = self._compare_func(op)


### PR DESCRIPTION
## What this PR fixes

Solves [#51](https://github.com/mdowds/python-mock-firestore/issues/51).

Bug – CollectionReference.get() returned the raw generator produced by stream().

In real google-cloud-firestore, get() is eager: it materialises the stream and returns a list[DocumentSnapshot].

Consuming code that expected parity (e.g. len(col.get()) or random-index access) raised TypeError: object of type 'generator' has no len().

## Backward Compatibility

No breaking changes. Existing code that already consumed the generator continues to work (list(col.get()) still returns a list). Only incorrect behaviour is corrected.