### PR TITLE
Fix DELETE_FIELD handling: silent no-op for missing fields + nested dict support in set(merge=True)

### DIFF
--- a/mockfirestore/_helpers.py
+++ b/mockfirestore/_helpers.py
@@ -77,6 +77,26 @@ class Timestamp:
         return str(self._timestamp).split('.')[1]
 
 
+def flatten_for_merge(data: Dict[str, Any], prefix: str = '') -> Dict[str, Any]:
+    """Flatten nested dicts into dot-notation keys for set(merge=True).
+
+    Firestore's set(merge=True) deep-merges at every nesting level.
+    The mock's update() already handles dot-notation keys correctly,
+    so flattening first lets the existing logic work for nested dicts.
+
+    Only plain dicts are recursed into; Firestore transform objects
+    (Sentinel, ArrayUnion, etc.) are treated as leaf values.
+    """
+    result: Dict[str, Any] = {}
+    for key, value in data.items():
+        full_key = '{}.{}'.format(prefix, key) if prefix else key
+        if isinstance(value, dict):
+            result.update(flatten_for_merge(value, prefix=full_key))
+        else:
+            result[full_key] = value
+    return result
+
+
 def get_document_iterator(document: Dict[str, Any], prefix: str = '') -> Iterator[Tuple[str, Any]]:
     """
     :returns: (dot-delimited path, value,)

--- a/mockfirestore/_helpers.py
+++ b/mockfirestore/_helpers.py
@@ -90,7 +90,7 @@ def flatten_for_merge(data: Dict[str, Any], prefix: str = '') -> Dict[str, Any]:
     result: Dict[str, Any] = {}
     for key, value in data.items():
         full_key = '{}.{}'.format(prefix, key) if prefix else key
-        if isinstance(value, dict):
+        if isinstance(value, dict) and value:
             result.update(flatten_for_merge(value, prefix=full_key))
         else:
             result[full_key] = value

--- a/mockfirestore/_transformations.py
+++ b/mockfirestore/_transformations.py
@@ -68,7 +68,10 @@ def _apply_updates(document: Dict[str, Any], data: Dict[str, Any]):
 def _apply_deletes(document: Dict[str, Any], data: List[str]):
     for key in data:
         path = key.split(".")
-        delete_by_path(document, path)
+        try:
+            delete_by_path(document, path)
+        except KeyError:
+            continue
 
 
 def _apply_arr_deletes(document: Dict[str, Any], data: Dict[str, Any]):

--- a/mockfirestore/document.py
+++ b/mockfirestore/document.py
@@ -4,7 +4,8 @@ import operator
 from typing import List, Dict, Any
 from mockfirestore import NotFound
 from mockfirestore._helpers import (
-    Timestamp, Document, Store, get_by_path, set_by_path, delete_by_path
+    Timestamp, Document, Store, get_by_path, set_by_path, delete_by_path,
+    flatten_for_merge
 )
 from mockfirestore._transformations import apply_transformations
 
@@ -85,7 +86,7 @@ class DocumentReference:
         data['__name__'] = self.id
         if merge:
             try:
-                self.update(data)
+                self.update(flatten_for_merge(data))
             except NotFound:
                 self.set(data)
         else:

--- a/tests/test_document_reference.py
+++ b/tests/test_document_reference.py
@@ -317,6 +317,39 @@ class TestDocumentReference(TestCase):
         doc = fs.collection("foo").document("first").get().to_dict()
         self.assertEqual(doc, {})
 
+    def test_document_update_transformerSentinelNonExistentField(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'spicy': 'tuna'}
+        }}
+        fs.collection('foo').document('first').update({"nonexistent": firestore.DELETE_FIELD})
+
+        doc = fs.collection("foo").document("first").get().to_dict()
+        self.assertEqual(doc, {'spicy': 'tuna'})
+
+    def test_document_update_transformerSentinelNonExistentNestedField(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'spicy': 'tuna'}
+        }}
+        fs.collection('foo').document('first').update({"stats.student123.field": firestore.DELETE_FIELD})
+
+        doc = fs.collection("foo").document("first").get().to_dict()
+        self.assertEqual(doc, {'spicy': 'tuna'})
+
+    def test_document_update_transformerSentinelMixedExistingAndNonExistent(self):
+        fs = MockFirestore()
+        fs._data = {'foo': {
+            'first': {'spicy': 'tuna', 'remove_me': 'gone'}
+        }}
+        fs.collection('foo').document('first').update({
+            "remove_me": firestore.DELETE_FIELD,
+            "nonexistent": firestore.DELETE_FIELD,
+        })
+
+        doc = fs.collection("foo").document("first").get().to_dict()
+        self.assertEqual(doc, {'spicy': 'tuna'})
+
     def test_document_update_transformerArrayRemoveBasic(self):
         fs = MockFirestore()
         fs._data = {"foo": {"first": {"arr": [1, 2, 3, 4]}}}


### PR DESCRIPTION
# Fix: DELETE_FIELD handling improvements

## Summary

Two fixes for `DELETE_FIELD` behavior to match real Firestore:

### 1. DELETE_FIELD on non-existent fields should be a silent no-op
- In real Firestore, calling `update()` with `firestore.DELETE_FIELD` on a field that doesn't exist is a silent no-op. In mock-firestore, it raised a `KeyError`.
- Wrapped `delete_by_path` in `_apply_deletes` with `try/except KeyError`, matching the pattern already used by `_apply_arr_deletes` in the same file.

### 2. `set(merge=True)` with nested dicts containing DELETE_FIELD
- In real Firestore, `set({"stats": {"student123": {"field": DELETE_FIELD}}}, merge=True)` deep-merges and deletes the nested field. In mock-firestore, this raised a `KeyError` because `apply_transformations` flattened nested dicts into dot-notation keys via `get_document_iterator`, then tried `del data[key]` using the dot-notation key as a literal top-level key lookup on the still-nested dict.
- Added `flatten_for_merge()` helper that converts nested dicts into dot-notation keys before `set(merge=True)` calls `update()`, so the existing transformation logic works correctly.

## Motivation

Batch updates that use `set(merge=True)` with nested dicts containing `DELETE_FIELD` (e.g., cleaning up fields that may or may not exist) would crash in tests using mock-firestore, even though they work fine against real Firestore.

## Changes

| File | Change |
|---|---|
| `mockfirestore/_transformations.py` | Catch `KeyError` in `_apply_deletes`, skip missing fields |
| `mockfirestore/_helpers.py` | Add `flatten_for_merge()` to convert nested dicts to dot-notation keys |
| `mockfirestore/document.py` | Use `flatten_for_merge()` in `set()` when `merge=True` |
| `tests/test_document_reference.py` | 3 new tests for DELETE_FIELD on non-existent fields |

## Test plan

- Existing `test_document_update_transformerSentinel` still passes (delete existing field)
- Existing `test_document_set_mergeNewValue` still passes (set with merge, flat data)
- New: DELETE_FIELD on non-existent top-level field — no error, doc unchanged
- New: DELETE_FIELD on non-existent nested dot-notation path — no error, doc unchanged
- New: Mixed existing + non-existing DELETE_FIELD — existing field deleted, non-existing silently ignored
- Verified end-to-end: `batch.set(ref, {"stats": {"student123": {"field": DELETE_FIELD}}}, merge=True)` now works correctly